### PR TITLE
Update qewd-client.js - ewd-token -> QEWDSession

### DIFF
--- a/qewd-client.js
+++ b/qewd-client.js
@@ -177,7 +177,7 @@ let start = function(application, $, customAjaxFn, url) {
           token = messageObj.message.token;
 
           QEWD.setCookie = function(name) {
-            name = name || 'ewd-token';
+            name = name || 'QEWDSession';
             document.cookie = name + "=" + token;
           };
 


### PR DESCRIPTION
I feel like this should be the same cookieName as the default that gets set on line 90. 

Maybe I'm not understanding the purpose here but I feel like these should be the same value by default, otherwise one has to manually keep them in sync